### PR TITLE
bucketeer導入でエラーを起こす

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,3 +1,4 @@
 module.exports = {
   reactStrictMode: true,
+  webpack5: false,
 }

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "@bucketeer/sdk": "^1.27.0",
     "next": "11.0.1",
     "react": "17.0.2",
     "react-dom": "17.0.2"

--- a/pages/bucketeer-test.tsx
+++ b/pages/bucketeer-test.tsx
@@ -1,0 +1,39 @@
+import { useRef, useEffect } from 'react'
+import { Bucketeer } from '@bucketeer/sdk'
+
+const HOST = 'https://api-media.bucketeer.jp';
+const TOKEN = '';　// ここには書きません
+
+export default function Home() {
+  const bucketeer = useRef<Bucketeer | null>(null);
+  useEffect(() => {
+    if(!bucketeer.current) {
+      // node側で実行すると「window is not defined」のエラーがでるのでクライアントだけで実行するようにしている
+      if(typeof window !== "undefined") {
+        import('@bucketeer/sdk').then((sdk) => {
+          const { initialize } = sdk;
+          bucketeer.current = initialize({
+            host: HOST,
+            token: TOKEN,
+            tag: "web",
+            user: {
+              id: "00000000-0000-0000-0000-ca633444b941",
+              data: {
+                foo: 'bar',
+              },
+            },
+            fetch: fetch,
+            pollingIntervalForGetEvaluations:2 * 60 * 1000,
+            pollingIntervalForRegisterEvents:2 * 60 * 1000,
+          });
+          console.table(bucketeer.current.getBuildInfo());
+          // ここでは「defaultValue」が出力される
+          console.log(bucketeer.current.getStringVariation('nmb-lp-title', 'defaultValue'));
+        });
+      }
+    }
+  },[]);
+  return (
+    <button onClick={()=> { if(bucketeer.current){ console.log(bucketeer.current.getStringVariation('nmb-lp-title', 'defaultValue')) } }}>bucketeerの状況を出力</button>
+  )
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -54,6 +54,14 @@
     lodash "^4.17.13"
     to-fast-properties "^2.0.0"
 
+"@bucketeer/sdk@^1.27.0":
+  version "1.27.0"
+  resolved "https://registry.yarnpkg.com/@bucketeer/sdk/-/sdk-1.27.0.tgz#6e7db2c602ae6b978eb1b4ef7bba398a66440443"
+  integrity sha512-PgVJTQvcaqs4O91Gdi1DiOJmclaI7y4vbzIgs1/sGBUiD8UPbj2RPRz6jpECIYNmSbYgOjOfoDEu48VQqX4hGQ==
+  dependencies:
+    option-t "^28.0.0"
+    uuid "^8.1.0"
+
 "@eslint/eslintrc@^0.4.3":
   version "0.4.3"
   resolved "https://registry.yarnpkg.com/@eslint/eslintrc/-/eslintrc-0.4.3.tgz#9e42981ef035beb3dd49add17acb96e8ff6f394c"
@@ -987,7 +995,7 @@ escape-string-regexp@^4.0.0:
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz#14ba83a5d373e3d311e5afca29cf5bfad965bf34"
   integrity sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==
 
-eslint-config-next@11.0.1:
+eslint-config-next@^11.0.1:
   version "11.0.1"
   resolved "https://registry.yarnpkg.com/eslint-config-next/-/eslint-config-next-11.0.1.tgz#abdd2565a6fa5841556a89ba935f044bec173d0b"
   integrity sha512-yy63K4Bmy8amE6VMb26CZK6G99cfVX3JaMTvuvmq/LL8/b8vKHcauUZREBTAQ+2DrIvlH4YrFXrkQ1vpYDL9Eg==
@@ -2127,6 +2135,11 @@ once@^1.3.0:
   dependencies:
     wrappy "1"
 
+option-t@^28.0.0:
+  version "28.1.1"
+  resolved "https://registry.yarnpkg.com/option-t/-/option-t-28.1.1.tgz#8f248f21e4f37525052d5121a09def1166b3e246"
+  integrity sha512-Tr0mesYhgZPz6f7gEN9KAxWf5bRefsWcgXvJ8NHwl/Od0JnUGW3avadEXRtmaQdFb0Fq9KDX6br3NRqW69CCXg==
+
 optionator@^0.9.1:
   version "0.9.1"
   resolved "https://registry.yarnpkg.com/optionator/-/optionator-0.9.1.tgz#4f236a6373dae0566a6d43e1326674f50c291499"
@@ -3099,6 +3112,11 @@ util@^0.12.0:
     is-typed-array "^1.1.3"
     safe-buffer "^5.1.2"
     which-typed-array "^1.1.2"
+
+uuid@^8.1.0:
+  version "8.3.2"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
+  integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
 
 v8-compile-cache@^2.0.3:
   version "2.3.0"


### PR DESCRIPTION
webpack4にした状態で`$ yarn run dev`を行うとこのようなエラーが起こる
<img width="701" alt="スクリーンショット 2021-08-02 15 15 55" src="https://user-images.githubusercontent.com/13197852/127812766-5b4cfe3f-8877-44f2-80e3-6fea65d123b0.png">

```
error - ./node_modules/@bucketeer/sdk/lib/api/registerEvents.mjs
Can't import the named export 'v4' from non EcmaScript module (only default export is available)
Could not find files for /bucketeer-test in .next/build-manifest.json
Could not find files for /bucketeer-test in .next/build-manifest.json
wait  - compiling...
error - ./node_modules/@bucketeer/sdk/lib/api/registerEvents.mjs
Can't import the named export 'v4' from non EcmaScript module (only default export is available)
event - compiled successfully
```

この記事にあるように外部ライブラリに含まれる.mjsファイルをデフォルトでロードしようとして発生しているエラーのよう
https://gunmagisgeek.com/blog/troubleshooting/6543